### PR TITLE
pure-prompt: update to 1.12.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3961,6 +3961,11 @@
     github = "oyren";
     name = "Moritz Scheuren";
   };
+  pablovsky = {
+    email = "dealberapablo07@gmail.com";
+    github = "pablo1107";
+    name = "Pablo Andres Dealbera";
+  };
   pacien = {
     email = "b4gx3q.nixpkgs@pacien.net";
     github = "pacien";

--- a/pkgs/shells/zsh/pure-prompt/default.nix
+++ b/pkgs/shells/zsh/pure-prompt/default.nix
@@ -4,13 +4,13 @@ with stdenv.lib;
 
 stdenv.mkDerivation rec {
   pname = "pure-prompt";
-  version = "1.11.0";
+  version = "1.12.0";
 
   src = fetchFromGitHub {
     owner = "sindresorhus";
     repo = "pure";
     rev = "v${version}";
-    sha256 = "0nzvb5iqyn3fv9z5xba850mxphxmnsiq3wxm1rclzffislm8ml1j";
+    sha256 = "1h04z7rxmca75sxdfjgmiyf1b5z2byfn6k4srls211l0wnva2r5y";
   };
 
   installPhase = ''
@@ -25,6 +25,6 @@ stdenv.mkDerivation rec {
     homepage = https://github.com/sindresorhus/pure;
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = with maintainers; [ pacien ];
+    maintainers = with maintainers; [ pacien pablovsky ];
   };
 }


### PR DESCRIPTION
Merge and squash with your previous commit if you consider useful.

Can I ask how you use it, because I find it weird the folder structure, maybe it's because you use it with home-manager and you link it to `~/.local/share`, right?