### PR TITLE
nixos/cgit: test list settings type

### DIFF
--- a/nixos/tests/cgit.nix
+++ b/nixos/tests/cgit.nix
@@ -27,6 +27,12 @@ in {
             desc = "some-repo description";
           };
         };
+        settings = {
+          readme = [
+            ":README.md"
+            ":date.txt"
+          ];
+        };
       };
 
       environment.systemPackages = [ pkgs.git ];
@@ -56,18 +62,41 @@ in {
       git init -b master reference
       cd reference
       git remote add origin /srv/git/some-repo
-      date > date.txt
+      { echo -n "cgit NixOS Test at "; date; } > date.txt
       git add date.txt
       git -c user.name=test -c user.email=test@localhost commit -m 'add date'
       git push -u origin master
     ''}")
 
+    # test web download
     server.succeed(
         "curl -fsS 'http://localhost/%28c%29git/some-repo/plain/date.txt?id=master' | diff -u reference/date.txt -"
     )
 
+    # test http clone
     server.succeed(
        "git clone http://localhost/%28c%29git/some-repo && diff -u reference/date.txt some-repo/date.txt"
+    )
+
+    # test list settings by greping for the fallback readme
+    server.succeed(
+        "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F 'cgit NixOS Test at'"
+    )
+
+    # add real readme
+    server.succeed(
+        "echo '# cgit NixOS test README' > reference/README.md",
+        "git -C reference add README.md",
+        "git -C reference -c user.name=test -c user.email=test@localhost commit -m 'add readme'",
+        "git -C reference push",
+    )
+
+    # test list settings by greping for the real readme
+    server.succeed(
+        "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F '# cgit NixOS test README'"
+    )
+    server.fail(
+        "curl -fsS 'http://localhost/%28c%29git/some-repo/about/' | grep -F 'cgit NixOS Test at'"
     )
   '';
 })


### PR DESCRIPTION
<!-- Nixpkgs has a lot of new incoming Pull Requests, but not enough people to review this constant stream. Even if you aren't a committer, we would appreciate reviews of other PRs, especially simple ones like package updates. Just testing the relevant package/service and leaving a comment saying what you tested, how you tested it and whether it worked would be great. List of open PRs: <https://github.com/NixOS/nixpkgs/pulls>, for more about reviewing contributions: <https://hydra.nixos.org/job/nixpkgs/trunk/manual/latest/download/1/nixpkgs/manual.html#sec-reviewing-contributions>. Reviewing isn't mandatory, but it would help out a lot and reduce the average time-to-merge for all of us. Thanks a lot if you do! -->
###### Motivation for this change

add test to <https://github.com/NixOS/nixpkgs/pull/317293>

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [x] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

###### Notify maintainers

cc @pacien
